### PR TITLE
Change title and update to Django 3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Grammars Under Threat
+# Grammars of Judeo-Spanish
 
 ## Getting Started
 

--- a/django/README.md
+++ b/django/README.md
@@ -1,11 +1,11 @@
-# Grammars Under Threat - Django Project
+# Grammars of Judeo-Spanish - Django Project
 
 This document is primarily designed for technical staff working on the development of the project (e.g. software engineers and system admins).
 
 
 ## Django Project
 
-The project is called 'grammars-under-threat', but project files are stored in the 'core' folder. Please refer to `core/settings.py` for further details
+The project is called 'judeospanish', but project files are stored in the 'core' folder. Please refer to `core/settings.py` for further details
 
 
 ## Django Apps
@@ -68,7 +68,7 @@ Our websites must comply with accessibility regulations. See the [BEAR Accessibi
 
 ## Database
 
-The SQLite3 database used sits in the Django project root folder (alongside this README file). It is not included within the Git repo, so must instead be requested from the system admin. Once you have a copy of this database, give it a suitable name like `grammars-under-threat.sqlite3` and place in the `django/` directory (same directory that stores `manage.py`). Remember to name this database in `local_settings.py` (see Settings section of this document for more details)
+The SQLite3 database used sits in the Django project root folder (alongside this README file). It is not included within the Git repo, so must instead be requested from the system admin. Once you have a copy of this database, give it a suitable name like `judeospanish.sqlite3` and place in the `django/` directory (same directory that stores `manage.py`). Remember to name this database in `local_settings.py` (see Settings section of this document for more details)
 
 
 ## Settings

--- a/django/core/local_settings.example.py
+++ b/django/core/local_settings.example.py
@@ -17,15 +17,15 @@ SECRET_KEY = ''
 DEBUG = True/False
 
 # Set to ['*'] if in development, or specific IP addresses and domains if in production
-ALLOWED_HOSTS = ['*']/['grammars-under-threat.bham.ac.uk']
+ALLOWED_HOSTS = ['*']/['judeospanish.bham.ac.uk']
 
 # Set the database name below
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'grammars-under-threat.sqlite3'),
+        'NAME': os.path.join(BASE_DIR, 'judeospanish.sqlite3'),
         'TEST': {
-            'NAME': os.path.join(BASE_DIR, 'grammars-under-threat_TEST.sqlite3'),
+            'NAME': os.path.join(BASE_DIR, 'judeospanish_TEST.sqlite3'),
         },
     }
 }

--- a/django/core/local_settings.test.py
+++ b/django/core/local_settings.test.py
@@ -18,9 +18,9 @@ ALLOWED_HOSTS = ['*']
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': os.path.join(BASE_DIR, 'grammars-under-threat.sqlite3'),
+        'NAME': os.path.join(BASE_DIR, 'judeospanish.sqlite3'),
         'TEST': {
-            'NAME': os.path.join(BASE_DIR, 'grammars-under-threat_TEST.sqlite3'),
+            'NAME': os.path.join(BASE_DIR, 'judeospanish_TEST.sqlite3'),
         },
     }
 }

--- a/django/core/settings.py
+++ b/django/core/settings.py
@@ -94,6 +94,12 @@ MEDIA_URL = '/media/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 
 
+# Default primary key field type
+# https://docs.djangoproject.com/en/latest/ref/settings/#default-auto-field
+
+DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+
 # Import local_settings.py
 SECRET_KEY = None
 try:

--- a/django/core/templates/base.html
+++ b/django/core/templates/base.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <title>Grammars Under Threat (Coming Soon)</title>
+    <title>Grammars of Judeo-Spanish (Coming Soon)</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/django/core/wsgi.py
+++ b/django/core/wsgi.py
@@ -1,5 +1,5 @@
 """
-WSGI config for grammars-under-threat project.
+WSGI config for judeospanish project.
 
 It exposes the WSGI callable as a module-level variable named ``application``.
 

--- a/django/general/templates/general/coming-soon.html
+++ b/django/general/templates/general/coming-soon.html
@@ -3,6 +3,6 @@
 
 {% block content %}
 <h1>Coming Soon</h1>
-<p>The <span class="highlight">Grammars Under Threat</span> website is under construction and will be coming soon.</p>
+<p>The <span class="highlight">Grammars of Judeo-Spanish</span> website is under construction and will be coming soon.</p>
 <p>For information about the project in the meantime, please email Alice Corr: <a href="mailto:a.corr@bham.ac.uk">a.corr@bham.ac.uk</a></p>
 {% endblock %}

--- a/django/general/templates/general/cookies.html
+++ b/django/general/templates/general/cookies.html
@@ -3,5 +3,5 @@
 
 {% block content %}
 <h1>Cookies</h1>
-<p>The Grammars Under Threat website does not use cookies. For more information about cookies, including what they are and how you can manage them, please visit the University of Birmingham’s <a href="https://www.birmingham.ac.uk/privacy/cookies.aspx">cookies policy page</a>.</p>
+<p>The Grammars of Judeo-Spanish website does not use cookies. For more information about cookies, including what they are and how you can manage them, please visit the University of Birmingham’s <a href="https://www.birmingham.ac.uk/privacy/cookies.aspx">cookies policy page</a>.</p>
 {% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 # Please follow suitable version specifiers, as outlined in https://www.python.org/dev/peps/pep-0440/#version-specifiers
 # For Django versioning we use ~= (e.g. Django~=3.1.0) which will keep the minor version up to date (e.g. the latest version prior to 3.2.0)
 
-Django~=3.1.0
+Django~=3.2.0


### PR DESCRIPTION
The project name changed from 'Grammars Under Threat' to 'Grammars of Judeo Spanish' or just 'judeospanish' for short. This MR updates the title throughout the project and upgrades to Django 3.2 from 3.1.