### PR TITLE
insert translation content

### DIFF
--- a/django/core/locale/en/LC_MESSAGES/django.po
+++ b/django/core/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-07-06 10:49+0100\n"
+"POT-Creation-Date: 2021-07-06 12:44+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -16,22 +16,23 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: core/settings.py:93
 msgid "English"
-msgstr "English"
+msgstr ""
 
 #: core/settings.py:94
 msgid "Ladino"
-msgstr "Ladino"
+msgstr ""
 
 #: core/templates/base.html:53
 msgid "ProjectTitle1"
-msgstr "Atlas Linguistiko de las Avlas"
+msgstr "Linguistic Atlas of"
 
 #: core/templates/base.html:53
 msgid "ProjectTitle2"
-msgstr "Djudeo-Espanyolas"
+msgstr "Judeo-Spanishes"
 
 #: core/templates/base.html:64
 msgid "Welcome"

--- a/django/core/settings.py
+++ b/django/core/settings.py
@@ -78,7 +78,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 # Internationalization
 
-LANGUAGE_CODE = 'en-gb'
+LANGUAGE_CODE = 'en'
 TIME_ZONE = 'Europe/London'
 USE_I18N = True
 USE_L10N = True
@@ -90,7 +90,7 @@ def gettext_noop(s):
 
 
 LANGUAGES = (
-        ('en-gb', _('English')),
+        ('en', _('English')),
         ('ld', gettext_noop('Ladino')),
 )
 

--- a/django/core/static/css/custom.css
+++ b/django/core/static/css/custom.css
@@ -19,7 +19,7 @@ a:hover {
 }
 
 h1 {
-    font-size: 1em;
+    font-size: 0.85em;
     margin: 0;
     padding: 0;
     line-height: 1em;
@@ -258,7 +258,6 @@ main a {
 #welcome-banner-title {
     text-align: center;
     padding-top: 30vh;
-    font-size: 3.6em;
     font-weight: 100;
 }
 

--- a/django/core/static/css/custom_large.css
+++ b/django/core/static/css/custom_large.css
@@ -6,8 +6,9 @@
     }
 
     .nav-link {
-        margin-left: 0.5em;
-        margin-right: 1em;
+        margin-left: 0.4em;
+        margin-right: 0.7em;
+        font-size: 0.97em;
     }
 
     /* ---------- Main ---------- */
@@ -21,7 +22,7 @@
 
     #welcome-banner-title {
         padding-top: 30vh;
-        font-size: 3.6em;
+        font-size: 3.2em;
     }
 
     #welcome-banner-tagline {

--- a/django/core/templates/base.html
+++ b/django/core/templates/base.html
@@ -6,13 +6,13 @@
 
     <head>
     
-        <title>Grammars of Judeo-Spanish</title>
+        <title>Linguistic Atlas of Judeo-Spanishes</title>
 
         <!--Meta-->
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1">
-        <meta name="description" content="Grammars of Judeo-Spanish research project website">
+        <meta name="description" content="Linguistic Atlas of Judeo-Spanishes research project website">
         <meta name="author" content="University of Birmingham">
 
         <!-- Fonts -->
@@ -50,7 +50,7 @@
         <!-- Navigation bar -->
         <nav class="navbar fixed-top navbar-expand-lg">
             <!-- Logo -->
-            <a class="navbar-brand" href="{% url 'welcome' %}"><h1><span>Grammars of</span> <strong>Judeo-Spanish</strong></h1></a>
+            <a class="navbar-brand" href="{% url 'welcome' %}"><h1><span>{% translate 'ProjectTitle1' %}</span> <strong>{% translate 'ProjectTitle2' %}</strong></h1></a>
             <!-- Nav toggle button (for small screens) -->
             <button class="navbar-toggler" type="button" title="navbartoggle" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false">
                 <i class="fas fa-bars"></i>
@@ -67,25 +67,25 @@
                     <!-- About -->
                     <li class="nav-item">
                         <a class="nav-link{% if '/about/' in request.path %} active{% endif %}" href="{% url 'about' %}">
-                            {% trans 'About' %}
+                            {% translate 'About' %}
                         </a>
                     </li>
                     <!-- Stories -->
                     <li class="nav-item">
                         <a class="nav-link{% if '/stories/' in request.path and '/create/' not in request.path %} active{% endif %}" href="{% url 'story-list' %}">
-                            {% trans 'Stories' %}
+                            {% translate 'Atlas' %}
                         </a>
                     </li>
                     <!-- Stories - Create -->
                     <li class="nav-item">
                         <a class="nav-link{% if '/stories/create/' in request.path %} active{% endif %}" href="{% url 'story-create' %}">
-                            {% trans 'Share' %}
+                            {% translate 'Share' %}
                         </a>
                     </li>
                     <!-- Participate -->
                     <li class="nav-item">
                         <a class="nav-link{% if '/participate/' in request.path %} active{% endif %}" href="{% url 'participant-create' %}">
-                            {% trans 'Participate' %}
+                            {% translate 'Get Involved' %}
                         </a>
                     </li>
                 </ul>
@@ -136,7 +136,8 @@
                 </div>
 
                 <p>
-                    Grammars of Judeo-Spanish is a research project led by <a href="https://www.birmingham.ac.uk/staff/profiles/languages/corr-alice.aspx">Dr Alice Corr</a> at the <a href="http://www.birmingham.ac.uk">University of Birmingham</a>
+                    Linguistic atlas of Judeo-Spanishes is a research project funded by the <a href="https://www.thebritishacademy.ac.uk/">British Academy</a> and <a href="https://www.leverhulme.ac.uk/">Leverhulme Trust</a> (SRG1819\191358)
+                    <br>and led by <a href="https://www.birmingham.ac.uk/staff/profiles/languages/corr-alice.aspx">Dr Alice Corr</a> at the <a href="http://www.birmingham.ac.uk">University of Birmingham</a>
                 </p>
                 <p>
                     This website has been developed by the <a href="http://www.birmingham.ac.uk/bear-software">Research Software Group</a> for the <a href="https://www.birmingham.ac.uk/university/colleges/artslaw/index.aspx">College of Arts and Law</a>

--- a/django/general/locale/en/LC_MESSAGES/django.po
+++ b/django/general/locale/en/LC_MESSAGES/django.po
@@ -70,7 +70,7 @@ msgstr ""
 msgid "AboutContact2"
 msgstr ""
 "If you're interested in getting involved in this project, please contact the "
-"Principal Investigator (Dr. Alice Corr) at a.corr(at)bham.ac.uk and/or "
+"Principal Investigator (Dr. Alice Corr) at a.corr@bham.ac.uk and/or "
 
 #: general/templates/general/about.html:21
 msgid "AboutContact3"
@@ -79,10 +79,9 @@ msgstr "register your interest here."
 #: general/templates/general/about.html:24
 msgid "AboutContact4"
 msgstr ""
-"For all other enquiries, please contact the Principal Investigator (Dr. "
-"Alice Corr) at a.corr(at)bham.ac.uk.You can also follow updates from the "
-"project on Twitter @linguafrancabhm.Postal address: Ashley Building, "
-"University of Birmingham, Edgbaston, B15 2TT, UK."
+"For all other enquiries, please contact the Principal Investigator (Dr. Alice Corr) at a.corr@bham.ac.uk"
+"<br><br>You can also follow updates from the project on Twitter <a href='https://twitter.com/linguafrancabhm'>@linguafrancabhm</a>."
+"<br><br>Postal address: Ashley Building, University of Birmingham, Edgbaston, B15 2TT, UK."
 
 #: general/templates/general/welcome.html:9
 msgid "ProjectTitle1"

--- a/django/general/locale/en/LC_MESSAGES/django.po
+++ b/django/general/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,132 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-07-06 12:44+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: general/templates/general/about.html:10
+msgid "AboutProject"
+msgstr "<h2>The Project</h2>"
+"<p>Led by Dr Alice Corr at the University of Birmingham, The Grammars of "
+"Judeo-Spanish is a documentation project which seeks to identify and map out "
+"the grammatical landscape of Judeo-Spanish varieties as they are spoken and "
+"written today. Whilst there are many reasons why such work is valuable, this "
+"project is particularly concerned with the following benefits:</"
+"p><ul><li><b>Fostering language survivance:</b> Because most Judeo-Spanish "
+"research focuses on other aspects of the linguistic system we simply do not "
+"know what the overall grammatical landscape of Judeo-Spanish looks like. "
+"Without a detailed or accurate knowledge of what Judeo-Spanish's sentence-"
+"level grammar is, the language cannot be taught or passed on to new learners "
+"or future generations. Providing a description of grammatical description "
+"can support community efforts to create and disseminate learning resources "
+"and other language survivance activities important to those for whom Judeo-"
+"Spanish is a component of their cultural and ancestral heritage and/or way "
+"of life.</li><li><b>Language policy for historic and minoritized languages:</"
+"b> Providing linguistically accurate data for Judeo-Spanish will promote "
+"evidence-based policymaking, by providing the necessary data with which to "
+"determine its linguistic classification and (re-)evaluate its official/"
+"recognised status in line with national and international language policies."
+"</li><p>The virtual linguistic atlas brings together a range of stories and "
+"personal narratives from members of Judeo-Spanish speaking diaspora. It "
+"collates existing recordings of Judeo-Spanish speakers with new, "
+"crowdsourced recordings and texts, providing an interactive, contemporary "
+"snapshot, and a major new dataset, of how current generations of Judeo-"
+"Spanish speak and write in this important historical language.</p><p>Hosted "
+"by the University of Birmingham, Grammars of Judeo-Spanish is generously "
+"funded by a British Academy and Leverhulme Trust grant.</p>"
+
+#: general/templates/general/about.html:13
+msgid "AboutProjectTeam"
+msgstr "<h2>Project Team</h2>"
+"<p><b>Principal Investigator:</b> Dr Alice Corr, University of Birmingham</"
+"p><p><b>Research Assistant:</b> Dr Carlos Yebra López, University of "
+"Birmingham and New York University</p><p><b>Undergraduate research assistant:"
+"</b> Mikey Barnes, University of Birmingham</p>"
+
+#: general/templates/general/about.html:17
+msgid "AboutContact1"
+msgstr ""
+"We are particularly interested in hearing from <b>native speakers</b> and "
+"<b>heritage speakers</b> of Judeo-Spanish, as well as those who have learned "
+"Judeo-Spanish later in life. We also welcome <b>other stakeholders, "
+"activists, researchers and educators</b> who are already working on Judeo-"
+"Spanish."
+
+#: general/templates/general/about.html:20
+msgid "AboutContact2"
+msgstr ""
+"If you're interested in getting involved in this project, please contact the "
+"Principal Investigator (Dr. Alice Corr) at a.corr(at)bham.ac.uk and/or "
+
+#: general/templates/general/about.html:21
+msgid "AboutContact3"
+msgstr "register your interest here."
+
+#: general/templates/general/about.html:24
+msgid "AboutContact4"
+msgstr ""
+"For all other enquiries, please contact the Principal Investigator (Dr. "
+"Alice Corr) at a.corr(at)bham.ac.uk.You can also follow updates from the "
+"project on Twitter @linguafrancabhm.Postal address: Ashley Building, "
+"University of Birmingham, Edgbaston, B15 2TT, UK."
+
+#: general/templates/general/welcome.html:9
+msgid "ProjectTitle1"
+msgstr "Linguistic atlas of"
+
+#: general/templates/general/welcome.html:9
+msgid "ProjectTitle2"
+msgstr "Judeo-Spanishes"
+
+#: general/templates/general/welcome.html:17
+msgid "WelcomeHeading"
+msgstr "Welcome"
+
+#: general/templates/general/welcome.html:19
+msgid "WelcomeMessage1"
+msgstr ""
+"This virtual linguistic atlas contains recordings and texts of stories and "
+"personal narratives as told by members of Judeo-Spanish speaking diaspora. "
+"It is funded by The Grammars of Judeo-Spanish, a documentation project which "
+"seeks to identify and map out the grammatical landscape of Judeo-Spanish "
+"varieties as they are spoken and written today."
+
+#: general/templates/general/welcome.html:22
+msgid "WelcomeMessage2"
+msgstr ""
+"We welcome contributions from language users of any variety of Judeo-Spanish "
+"(Ladino, Haketia). Whether you (or someone you know) acquired Judeo-Spanish "
+"in childhood, or learned it later in life, we would love to receive your "
+"stories!"
+
+#: general/templates/general/welcome.html:23
+msgid "WelcomeMessage3"
+msgstr "Share your story here"
+
+#: general/templates/general/welcome.html:26
+msgid "WelcomeMessage4"
+msgstr ""
+"You can also get involved in our grammatical documentation research survey "
+"by "
+
+#: general/templates/general/welcome.html:27
+msgid "WelcomeMessage5"
+msgstr "registering your interest here"
+
+#: general/templates/general/welcome.html:30
+msgid "WelcomeMessage6"
+msgstr "Enter the atlas"

--- a/django/general/locale/ld/LC_MESSAGES/django.po
+++ b/django/general/locale/ld/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-02 15:21+0100\n"
+"POT-Creation-Date: 2021-07-06 10:49+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,10 +17,38 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: general/templates/general/welcome.html:8
-msgid "WelcomeHeading"
-msgstr "Translated welcome in Ladino"
+#: general/templates/general/welcome.html:9
+msgid "ProjectTitle1"
+msgstr "Atlas Linguistiko de las Avlas"
 
-#: general/templates/general/welcome.html:10
-msgid "WelcomeMessage"
-msgstr "Translated welcome message in Ladino"
+#: general/templates/general/welcome.html:9
+msgid "ProjectTitle2"
+msgstr "Djudeo-Espanyolas"
+
+#: general/templates/general/welcome.html:17
+msgid "WelcomeHeading"
+msgstr ""
+
+#: general/templates/general/welcome.html:19
+msgid "WelcomeMessage1"
+msgstr ""
+
+#: general/templates/general/welcome.html:22
+msgid "WelcomeMessage2"
+msgstr ""
+
+#: general/templates/general/welcome.html:23
+msgid "WelcomeMessage3"
+msgstr ""
+
+#: general/templates/general/welcome.html:26
+msgid "WelcomeMessage4"
+msgstr ""
+
+#: general/templates/general/welcome.html:27
+msgid "WelcomeMessage5"
+msgstr ""
+
+#: general/templates/general/welcome.html:30
+msgid "WelcomeMessage6"
+msgstr ""

--- a/django/general/templates/general/about.html
+++ b/django/general/templates/general/about.html
@@ -1,24 +1,30 @@
 {% extends "base.html" %}
 {% load static %}
+{% load i18n %}
 
 {% block main %}
 
     <div class="container">
 
-        <h2>The Project</h2>
-        <p>
-            Text to go here
-        </p>
+        <!-- Project -->
+        {% translate 'AboutProject' %}
 
-        <h2>Project Team</h2>
-        <p>
-            Text to go here
-        </p>
+        <!-- Project Team -->
+        {% translate 'AboutProjectTeam' %}
 
+        <!-- Contact Us -->
         <h2>Contact Us</h2>
         <p>
-            Text to go here
+            {% translate 'AboutContact1' %}
         </p>
+        <p>
+            {% translate 'AboutContact2' %}
+            <a href="{% url 'participant-create' %}">{% translate 'AboutContact3' %}</a>
+        </p>
+        <p>
+            {% translate 'AboutContact4' %}
+        </p>
+
     </div>
     
 {% endblock %}

--- a/django/general/templates/general/welcome.html
+++ b/django/general/templates/general/welcome.html
@@ -6,7 +6,7 @@
     
     <div id="welcome-banner">
         <div id="welcome-banner-title">
-            <span>Grammars of</span> <strong>Judeo-Spanish</strong>
+            <span>{% translate 'ProjectTitle1' %}</span> <strong>{% translate 'ProjectTitle2' %}</strong>
         </div>
         <div id="welcome-banner-tagline">
             A research project led by Dr Alice Corr at the University of Birmingham
@@ -14,9 +14,20 @@
     </div>
     
     <div class="container">
-        <h2>{% trans 'WelcomeHeading' %}</h2>
+        <h2>{% translate 'WelcomeHeading' %}</h2>
         <p>
-            {% trans 'WelcomeMessage' %}
+            {% translate 'WelcomeMessage1' %}
+        </p>
+        <p>
+            {% translate 'WelcomeMessage2' %}
+            <a href="{% url 'story-create' %}">{% translate 'WelcomeMessage3' %}</a>
+        </p>
+        <p>
+            {% translate 'WelcomeMessage4' %}
+            <a href="{% url 'participant-create' %}">{% translate 'WelcomeMessage5' %}</a>
+        </p>
+        <p>
+            <a href="{% url 'story-list' %}">{% translate 'WelcomeMessage6' %}</a>
         </p>
     </div>
 

--- a/django/researchdata/admin.py
+++ b/django/researchdata/admin.py
@@ -2,7 +2,7 @@ from django.contrib import admin
 from . import models
 
 # Set the title of the dashboard
-admin.site.site_header = 'Grammars of Judeo-Spanish: Admin Dashboard'
+admin.site.site_header = 'Linguistic Atlas of Judeo-Spanishes: Admin Dashboard'
 
 
 def admin_publish_selected(modeladmin, request, queryset):

--- a/django/researchdata/locale/en/LC_MESSAGES/django.po
+++ b/django/researchdata/locale/en/LC_MESSAGES/django.po
@@ -1,0 +1,149 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2021-07-06 12:44+0100\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: researchdata/forms.py:13 researchdata/forms.py:84
+msgid "Share your story"
+msgstr ""
+
+#: researchdata/forms.py:14
+msgid "YouTube video link"
+msgstr ""
+
+#: researchdata/forms.py:15
+msgid "e.g. https://youtube.com/examplevideo"
+msgstr ""
+
+#: researchdata/forms.py:17
+msgid "Location (if not available above)"
+msgstr ""
+
+#: researchdata/forms.py:20 researchdata/forms.py:71
+msgid "Knowledge of Judeo-Spanish"
+msgstr ""
+
+#: researchdata/forms.py:21 researchdata/forms.py:74
+msgid "Languages known"
+msgstr ""
+
+#: researchdata/forms.py:24 researchdata/forms.py:35 researchdata/forms.py:77
+#: researchdata/forms.py:82
+msgid "Select all that apply"
+msgstr ""
+
+#: researchdata/forms.py:26 researchdata/forms.py:60
+msgid "Name"
+msgstr ""
+
+#: researchdata/forms.py:27 researchdata/forms.py:61
+msgid "Optional. Your name will not be displayed on the website."
+msgstr ""
+
+#: researchdata/forms.py:29 researchdata/forms.py:63
+msgid "Email"
+msgstr ""
+
+#: researchdata/forms.py:30 researchdata/forms.py:64
+msgid "Optional. Your email address will not be displayed on the website."
+msgstr ""
+
+#: researchdata/forms.py:32
+msgid "I agree to my data being used for the following"
+msgstr ""
+
+#: researchdata/forms.py:66
+msgid "Location of birth (if not available above)"
+msgstr ""
+
+#: researchdata/forms.py:68
+msgid "Current location (if not available above)"
+msgstr ""
+
+#: researchdata/forms.py:72
+msgid "By what name(s) do you call Judeo-Spanish?"
+msgstr ""
+
+#: researchdata/forms.py:79
+msgid "I'm interested in participating in"
+msgstr ""
+
+#: researchdata/templates/researchdata/participant-create.html:9
+msgid "ParticipateTitle"
+msgstr "Get Involved"
+
+#: researchdata/templates/researchdata/participant-create.html:11
+msgid "ParticipateIntro1"
+msgstr "You can get involved by "
+
+#: researchdata/templates/researchdata/participant-create.html:12
+msgid "ParticipateIntro2"
+msgstr "sharing your story here "
+
+#: researchdata/templates/researchdata/participant-create.html:13
+msgid "ParticipateIntro3"
+msgstr ""
+"or by participating in our grammatical documentation research survey. To "
+"register your interest in the grammatical documentation research survey, "
+"please complete the form below."
+
+#: researchdata/templates/researchdata/participant-create.html:16
+msgid "ParticipateIntro4"
+msgstr ""
+"We are particularly interested in hearing from native speakers and heritage "
+"speakers of Judeo-Spanish, as well as those who have learned Judeo-Spanish "
+"later in life. We also welcome other stakeholders, activists, researchers "
+"and educators who are already working on Judeo-Spanish."
+
+#: researchdata/templates/researchdata/participant-create.html:19
+msgid "ParticipateIntro5"
+msgstr ""
+"We will contact all interested parties when the project reaches the "
+"interview and data collection stage."
+
+#: researchdata/templates/researchdata/participant-create.html:27
+msgid "ParticipateSubmit"
+msgstr "Submit"
+
+#: researchdata/templates/researchdata/participant-create.html:29
+msgid "ParticipateSubmitNotes"
+msgstr ""
+
+#: researchdata/templates/researchdata/story-create.html:9
+msgid "ShareTitle"
+msgstr "Share Your Story"
+
+#: researchdata/templates/researchdata/story-create.html:11
+msgid "ShareIntro"
+msgstr "<p>Have a story, recording or text you’d like to share? You can submit your stories, conversations, or personal narratives as text, as audio/video, or as text and audio/video. You can also submit an accompanying image. We also ask you to provide some brief information about the speaker (e.g. location) for it to appear on the atlas. Please note that we review all submissions prior to publication, so you should expect a short delay between submitting your story and it appearing on the atlas.</p>"
+"<p>Follow the instructions below to contribute your story to the atlas.</p>"
+"<p>Already have a video/audio you want to share?</p>"
+"<p><b>Yes:</b><br> If your video already has a URL, please complete the form at the bottom of this page to submit your story to the atlas.</p>"
+"<p>If your video does not already have a URL, please upload the file to YouTube (<a href='https://learn.g2.com/how-to-upload-a-video-to-youtube'>instructions here</a>), or to any other audio/video-hosting platform. Once uploaded, copy the URL. You can then complete the form at the bottom of this page to submit your story to the atlas.</p>"
+"<p><b>No, but I want to make one:</b><br><i>Instructions for recording:</i> Find a speaker who speaks a dialect of Judeo-Spanish (this could be yourself!) and is willing to make a short video or audio recording. The speaker can tell a story from their past or their current life (e.g. an event from their childhood or youth, a past memory, or family story passes down from an older generation), a short story (e.g. fairy tale) or can even invent one! We also welcome reflections about the language itself, including views about the language’s future. If there’s more than one speaker, you can also record a conversation.</p>"
+"<p>Record the speaker with your phone. Then upload the audio/video file to YouTube (<a href='https://learn.g2.com/how-to-upload-a-video-to-youtube'>instructions here</a>) or to any other audio/video-hosting platform. When the YouTube video is ready, copy the URL. You can then upload the recording to our website by completing the form at the bottom of this page</p>"
+"<p>If you are unable to upload your recording to YouTube, you can <a href='https://birminghamcoaal.eu.qualtrics.com/jfe/form/SV_3vEQ8b2WWiHESXQ'>send us your file here</a>. Please note that this will take us longer to process.</p>"
+"<p><b>No, I just want to share my story as a text:</b><br>Please complete the form at the bottom of this page to submit your story to the atlas.</p>"
+
+#: researchdata/templates/researchdata/story-create.html:18
+msgid "ShareSubmit"
+msgstr "Submit"
+
+#: researchdata/templates/researchdata/story-create.html:20
+msgid "ShareSubmitNotes"
+msgstr ""

--- a/django/researchdata/locale/ld/LC_MESSAGES/django.po
+++ b/django/researchdata/locale/ld/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-06-02 15:21+0100\n"
+"POT-Creation-Date: 2021-07-06 10:49+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: researchdata/forms.py:13
+#: researchdata/forms.py:13 researchdata/forms.py:84
 msgid "Share your story"
 msgstr ""
 
@@ -29,18 +29,87 @@ msgstr ""
 msgid "e.g. https://youtube.com/examplevideo"
 msgstr ""
 
-#: researchdata/forms.py:16
+#: researchdata/forms.py:17
 msgid "Location (if not available above)"
 msgstr ""
 
-#: researchdata/forms.py:17
+#: researchdata/forms.py:20 researchdata/forms.py:71
 msgid "Knowledge of Judeo-Spanish"
 msgstr ""
 
-#: researchdata/forms.py:18
+#: researchdata/forms.py:21 researchdata/forms.py:74
 msgid "Languages known"
 msgstr ""
 
-#: researchdata/forms.py:21
+#: researchdata/forms.py:24 researchdata/forms.py:35 researchdata/forms.py:77
+#: researchdata/forms.py:82
 msgid "Select all that apply"
+msgstr ""
+
+#: researchdata/forms.py:26 researchdata/forms.py:60
+msgid "Name"
+msgstr ""
+
+#: researchdata/forms.py:27 researchdata/forms.py:61
+msgid "Optional. Your name will not be displayed on the website."
+msgstr ""
+
+#: researchdata/forms.py:29 researchdata/forms.py:63
+msgid "Email"
+msgstr ""
+
+#: researchdata/forms.py:30 researchdata/forms.py:64
+msgid "Optional. Your email address will not be displayed on the website."
+msgstr ""
+
+#: researchdata/forms.py:32
+msgid "I agree to my data being used for the following"
+msgstr ""
+
+#: researchdata/forms.py:66
+msgid "Location of birth (if not available above)"
+msgstr ""
+
+#: researchdata/forms.py:68
+msgid "Current location (if not available above)"
+msgstr ""
+
+#: researchdata/forms.py:72
+msgid "By what name(s) do you call Judeo-Spanish?"
+msgstr ""
+
+#: researchdata/forms.py:79
+msgid "I'm interested in participating in"
+msgstr ""
+
+#: researchdata/templates/researchdata/participant-create.html:9
+msgid "Participate"
+msgstr ""
+
+#: researchdata/templates/researchdata/participant-create.html:11
+msgid "ParticipateIntro"
+msgstr ""
+
+#: researchdata/templates/researchdata/participant-create.html:18
+msgid "ParticipateSubmit"
+msgstr ""
+
+#: researchdata/templates/researchdata/participant-create.html:20
+msgid "ParticipateSubmitNotes"
+msgstr ""
+
+#: researchdata/templates/researchdata/story-create.html:9
+msgid "ShareYourStory"
+msgstr ""
+
+#: researchdata/templates/researchdata/story-create.html:11
+msgid "ShareIntro"
+msgstr ""
+
+#: researchdata/templates/researchdata/story-create.html:18
+msgid "ShareSubmit"
+msgstr ""
+
+#: researchdata/templates/researchdata/story-create.html:20
+msgid "ShareSubmitNotes"
 msgstr ""

--- a/django/researchdata/templates/researchdata/participant-create.html
+++ b/django/researchdata/templates/researchdata/participant-create.html
@@ -6,18 +6,27 @@
 
     <div class="container">
 
-        <h2>{% trans 'Participate' %}</h2>
+        <h2>{% translate 'ParticipateTitle' %}</h2>
         <p>
-            {% trans 'ParticipateIntro' %}
+            {% translate 'ParticipateIntro1' %}
+            <a href="{% url 'story-create' %}">{% translate 'ParticipateIntro2' %}</a>
+            {% translate 'ParticipateIntro3' %}
         </p>
+        <p>
+            {% translate 'ParticipateIntro4' %}
+        </p>
+        <p>
+            {% translate 'ParticipateIntro5' %}
+        </p>
+
 
         <form id="participate-create-form" enctype="multipart/form-data" name="form" method="POST" action="{% url 'participant-create' %}">
             {% csrf_token %}
             {{ form.as_p }}
 
-            <button id="participant-create-submit" type="submit">{% trans 'ParticipateSubmit' %}</button>
+            <button id="participant-create-submit" type="submit">{% translate 'ParticipateSubmit' %}</button>
             <div class="form-submit-notes">
-                {% trans 'ParticipateSubmitNotes' %}
+                {% translate 'ParticipateSubmitNotes' %}
             </div>
         </form>
 

--- a/django/researchdata/templates/researchdata/story-create.html
+++ b/django/researchdata/templates/researchdata/story-create.html
@@ -6,18 +6,18 @@
 
     <div class="container">
 
-        <h2>{% trans 'ShareYourStory' %}</h2>
+        <h2>{% translate 'ShareTitle' %}</h2>
         <p>
-            {% trans 'ShareIntro' %}
+            {% translate 'ShareIntro' %}
         </p>
 
         <form id="story-create-form" enctype="multipart/form-data" name="form" method="POST" action="{% url 'story-create' %}">
             {% csrf_token %}
             {{ form.as_p }}
 
-            <button id="story-create-submit" type="submit">{% trans 'ShareSubmit' %}</button>
+            <button id="story-create-submit" type="submit">{% translate 'ShareSubmit' %}</button>
             <div class="form-submit-notes">
-                {% trans 'ShareSubmitNotes' %}
+                {% translate 'ShareSubmitNotes' %}
             </div>
         </form>
 

--- a/django/researchdata/templates/researchdata/story-list.html
+++ b/django/researchdata/templates/researchdata/story-list.html
@@ -10,14 +10,6 @@
         </div>
     </section>
 
-    <section class="container">
-        <h2>Stories</h2>
-        <p>
-            Text here
-        </p>
-    </section>
-
-
     <!-- Map - using Leaflet -->
     <!-- Load Leaflet -->
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.7.1/dist/leaflet.css" />


### PR DESCRIPTION
- Alice has provided most text content for the website (only in English so far).
- This MR adds this content in the English translation (and a few bits in Ladino).
- Full Ladino translations to be added in the future.
- Some CSS tweaks have been made based on the new text content.
- Alice has also changed the name of the project... again... so it's now Linguistic Atlas of Judeo-Spanishes, which has been updated throughout the site. Domain name doesn't need updating.